### PR TITLE
Support Gaussian mixture input distributions (linear only)

### DIFF
--- a/polyapprox/ols.py
+++ b/polyapprox/ols.py
@@ -71,7 +71,7 @@ ACT_TO_EVS = {
 # Mapping from activation functions to EVs of their derivatives
 ACT_TO_PRIME_EVS = {
     "gelu": gelu_prime_ev,
-    "identity": lambda mu, sigma: 1.0,
+    "identity": lambda mu, sigma: np.ones_like(mu),
     "relu": relu_prime_ev,
     "sigmoid": partial(gauss_hermite, sigmoid_prime),
     "swish": partial(gauss_hermite, swish_prime),

--- a/polyapprox/ols.py
+++ b/polyapprox/ols.py
@@ -104,26 +104,28 @@ def ols(
         b1: Bias vector of the first layer.
         W2: Weight matrix of the second layer.
         b2: Bias vector of the second layer.
-        mean: Mean of the input distribution. If None, the mean is zero.
-        cov: Covariance of the input distribution. If None, the covariance is the
-            identity matrix.
+        mean: Mean of the input distribution. Can include a batch dimension, denoting
+            a Gaussian mixture with the specified means. If None, the mean is zero.
+        cov: Covariance of the input distribution. Can include a batch dimension,
+            denoting a Gaussian mixture with the specified covariance matrices. If
+            None, the covariance is the identity matrix.
     """
     d_input = W1.shape[1]
     xp = array_api_compat.array_namespace(W1, b1, W2, b2)
 
     # Preactivations are Gaussian; compute their mean and standard deviation
     if cov is not None:
-        preact_cov = W1 @ cov @ W1.T
+        preact_cov = xp.linalg.matrix_transpose(cov @ W1.T) @ W1.T  # Supports batches
         cross_cov = cov @ W1.T
     else:
         preact_cov = W1 @ W1.T
         cross_cov = W1.T
 
     preact_mean = b1
-    preact_var = xp.diag(preact_cov)
+    preact_var = xp.linalg.diagonal(preact_cov)
     preact_std = xp.sqrt(preact_var)
     if mean is not None:
-        preact_mean = preact_mean + W1 @ mean
+        preact_mean = preact_mean + mean @ W1.T
 
     try:
         act_ev = ACT_TO_EVS[act]
@@ -135,11 +137,27 @@ def ols(
     # with the activations. We need the expected derivative of the
     # activation function with respect to the preactivation.
     act_prime_mean = act_prime_ev(preact_mean, preact_std)
-    output_cross_cov = (cross_cov * act_prime_mean) @ W2.T
+    output_cross_cov = (cross_cov * act_prime_mean[..., None, :]) @ W2.T
 
     # Compute expectation of act_fn(x) for each preactivation
     act_mean = act_ev(preact_mean, preact_std)
-    output_mean = W2 @ act_mean + b2
+    output_mean = act_mean @ W2.T + b2
+
+    # Law of total covariance
+    if cov is not None and cov.ndim > 2:
+        cov = cov.mean(axis=0)  # type: ignore
+
+        # Account for different means
+        if mean is not None and mean.ndim > 1:
+            # Covariance of the means
+            avg_mean = mean.mean(axis=0)  # type: ignore
+            cov += mean.T @ mean / len(mean) - xp.outer(avg_mean, avg_mean)
+
+    # Average over mixture components if necessary
+    if mean is not None and mean.ndim > 1:
+        mean = mean.mean(axis=0)  # type: ignore
+        output_cross_cov = output_cross_cov.mean(axis=0)
+        output_mean = output_mean.mean(axis=0)
 
     # beta = Cov(x)^-1 Cov(x, f(x))
     if cov is not None:
@@ -149,7 +167,7 @@ def ols(
 
     alpha = output_mean
     if mean is not None:
-        alpha -= beta.T @ mean
+        alpha -= mean @ beta
 
     if order == "quadratic":
         # Get indices to all unique pairs of input dimensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
 ]
 version = "0.1.0"
 
+[project.optional-dependencies]
+dev = [
+    "pre-commit",
+    "statsmodels",
+]
+
 [tool.pyright]
 include = ["polyapprox*"]
 reportPrivateImportUsage = false

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -1,6 +1,15 @@
 import numpy as np
+import pytest
+import statsmodels.api as sm
+from scipy.stats import multivariate_normal as mvn
+from statsmodels.regression.linear_model import OLS
 
+from polyapprox.gelu import gelu
 from polyapprox.ols import ols
+
+
+def relu(x):
+    return np.maximum(0, x)
 
 
 def test_ols_relu():
@@ -20,7 +29,7 @@ def test_ols_relu():
     # Monte Carlo check that the FVU is below 1
     n = 10_000
     x = np.random.randn(n, d)
-    y = np.maximum(0, x @ W1.T) @ W2.T
+    y = relu(x @ W1.T) @ W2.T
 
     # Quadratic FVU should be lower than linear FVU, which should be lower than 1
     lin_fvu = np.square(y - lin_res(x)).sum() / np.square(y).sum()
@@ -37,3 +46,52 @@ def test_ols_relu():
     np.testing.assert_allclose(lin_res.alpha, 0)
     np.testing.assert_allclose(quad_res.alpha, 0)
     np.testing.assert_allclose(quad_res.gamma, 0)
+
+
+@pytest.mark.parametrize("act", ["gelu", "relu"])
+@pytest.mark.parametrize("k", [1, 2, 3])
+def test_ols_monte_carlo(act: str, k: int):
+    # Determinism
+    np.random.seed(0)
+
+    # Choose activation function
+    act_fn = gelu if act == "gelu" else relu
+
+    # Implement the MLP
+    def mlp(x, W1, b1, W2, b2):
+        return act_fn(x @ W1.T + b1) @ W2.T + b2
+
+    d_in = 10
+    d_inner = 1_000
+    d_out = 1
+
+    # Construct a random Gaussian mixture with k components
+    # random psd matrix d_in x d_in
+    A = np.random.randn(k, d_in, d_in) / np.sqrt(d_in)
+    cov_x = A @ A.mT
+    mu_x = np.random.randn(k, d_in)
+
+    W1 = np.random.randn(d_inner, d_in) / np.sqrt(d_in)
+    W2 = np.random.randn(d_out, d_inner) / np.sqrt(d_inner)
+    b1 = np.random.randn(d_inner) / np.sqrt(d_in)
+    b2 = np.random.randn(d_out)
+
+    # Compute analytic coefficients
+    analytic = ols(W1, b1, W2, b2, act=act, cov=cov_x.squeeze(), mean=mu_x.squeeze())
+
+    # Generate Monte Carlo data
+    x = np.concatenate(
+        [mvn.rvs(mean=mu_x[i], cov=cov_x[i], size=10_000) for i in range(k)]
+    )
+    y = mlp(x, W1, b1, W2, b2)
+
+    # Use statsmodels to approximate the coefficients
+    X = sm.add_constant(x)
+    empirical = OLS(y.squeeze(), X).fit()
+
+    # Check that analytic coefficients are within the confidence interval
+    lo, hi = empirical.conf_int(0.01).T
+    analytic_beta = analytic.beta.squeeze()
+
+    assert lo[0] < analytic.alpha < hi[0]
+    assert np.all((lo[1:] < analytic_beta) & (analytic_beta < hi[1:]))


### PR DESCRIPTION
You can now feed `ols` a batch of _k_ `mean` and `cov` values, which indicates that the input distribution is a Gaussian mixture of _k_ components with the specified means and covariance matrices. We've added a new Monte Carlo test using `statsmodels` to check that the exact analytical coefficients match the approximate empirical ones up to the estimated confidence interval.