### PR TITLE
Jump relu added

### DIFF
--- a/polyapprox/jump_relu.py
+++ b/polyapprox/jump_relu.py
@@ -11,7 +11,6 @@ def jump_relu_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
     """Expected value of JumpReLU(x) under N(mu, sigma)"""
     return mu * (1-norm_cdf((1-mu) / sigma)) + sigma * norm_pdf((1-mu) / sigma)
 
-
 def jump_relu_prime_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
     """Expected value of JumpReLU'(x) under N(mu, sigma)"""
     return norm_pdf((1-mu) / sigma)

--- a/polyapprox/jump_relu.py
+++ b/polyapprox/jump_relu.py
@@ -14,7 +14,7 @@ def jump_relu_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
 
 def jump_relu_prime_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
     """Expected value of JumpReLU'(x) under N(mu, sigma)"""
-    return norm_cdf((1-mu) / sigma)
+    return norm_pdf((1-mu) / sigma)
 
 
 def jump_relu_poly_ev(n: int, mu: ArrayType, sigma: ArrayType) -> ArrayType:

--- a/polyapprox/jump_relu.py
+++ b/polyapprox/jump_relu.py
@@ -1,0 +1,66 @@
+import math
+
+import array_api_compat
+from scipy.special import factorial2
+
+from .backends import ArrayType, norm_cdf, norm_pdf
+
+# All of these functions assume theta = 1.0, which we can switch everything to be like
+
+def jump_relu_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
+    """Expected value of JumpReLU(x) under N(mu, sigma)"""
+    return mu * (1-norm_cdf((1-mu) / sigma)) + sigma * norm_pdf((1-mu) / sigma)
+
+
+def jump_relu_prime_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
+    """Expected value of JumpReLU'(x) under N(mu, sigma)"""
+    return norm_cdf((1-mu) / sigma)
+
+
+def jump_relu_poly_ev(n: int, mu: ArrayType, sigma: ArrayType) -> ArrayType:
+    """
+    Compute E[x^n * JumpReLU(x)] analytically where x ~ N(mu, sigma^2)
+
+    Parameters:
+    n     : int, the exponent n in x^n * ReLU(x)
+    mu    : ArrayLike, the mean(s) of the normal distribution(s)
+    sigma : ArrayLike, the standard deviation(s) of the normal distribution(s)
+
+    Returns:
+    result : NDArray, the computed expected value(s)
+    """
+    xp = array_api_compat.array_namespace(mu, sigma)
+
+    loc = (1-mu) / sigma # Single change from relu
+    expected_value = xp.zeros_like(mu)
+
+    # Precompute standard normal PDF and CDF at loc
+    phi_loc = norm_pdf(loc)  # PDF of standard normal at loc
+    Phi_loc = norm_cdf(loc)  # CDF of standard normal at loc
+
+    # Compute M_0 and M_1
+    M = [Phi_loc, -phi_loc]
+
+    # Compute higher-order M_k recursively
+    for k in range(2, n + 2):
+        M.append(-(loc ** (k - 1)) * phi_loc + (k - 1) * M[k - 2])
+
+    # Sum over k from 0 to n+1
+    for k in range(n + 2):
+        binom_coeff = math.comb(n + 1, k)
+        mu_power = mu ** (n + 1 - k)
+        sigma_power = sigma**k
+
+        # We need to compute an "upper" integral from loc to infinity, but all the
+        # formulas are for lower integrals from -infinity to loc. We compute the
+        # full integral and then we can get the upper by subtracting the lower.
+        if k == 0:
+            full = 1
+        elif k % 2:
+            full = 0
+        else:
+            full = factorial2(k - 1)
+
+        expected_value += binom_coeff * mu_power * sigma_power * (full - M[k])
+
+    return expected_value

--- a/polyapprox/jump_relu.py
+++ b/polyapprox/jump_relu.py
@@ -5,7 +5,16 @@ from scipy.special import factorial2
 
 from .backends import ArrayType, norm_cdf, norm_pdf
 
-# All of these functions assume theta = 1.0, which we can switch everything to be like
+raise ImportWarning(
+    """
+    JumpReLU currently fails certain tests of OLS regression, though the values are typically close.
+    I don't know if this is an issue with the OLS implementation or the JumpReLU itself.
+    Use at your own risk.
+    """
+)
+
+# All of these functions assume theta = 1.0, which loses no generality because
+# we can always rescale our weights and biases to get an equivalent network.
 
 def jump_relu_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
     """Expected value of JumpReLU(x) under N(mu, sigma)"""

--- a/polyapprox/jump_relu.py
+++ b/polyapprox/jump_relu.py
@@ -13,7 +13,7 @@ def jump_relu_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
 
 def jump_relu_prime_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
     """Expected value of JumpReLU'(x) under N(mu, sigma)"""
-    return norm_pdf((1-mu) / sigma)
+    return norm_cdf((mu-1) / sigma)
 
 
 def jump_relu_poly_ev(n: int, mu: ArrayType, sigma: ArrayType) -> ArrayType:

--- a/polyapprox/jump_relu.py
+++ b/polyapprox/jump_relu.py
@@ -5,14 +5,6 @@ from scipy.special import factorial2
 
 from .backends import ArrayType, norm_cdf, norm_pdf
 
-raise ImportWarning(
-    """
-    JumpReLU currently fails certain tests of OLS regression, though the values are typically close.
-    I don't know if this is an issue with the OLS implementation or the JumpReLU itself.
-    Use at your own risk.
-    """
-)
-
 # All of these functions assume theta = 1.0, which loses no generality because
 # we can always rescale our weights and biases to get an equivalent network.
 

--- a/polyapprox/jump_relu.py
+++ b/polyapprox/jump_relu.py
@@ -11,9 +11,18 @@ def jump_relu_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
     """Expected value of JumpReLU(x) under N(mu, sigma)"""
     return mu * (1-norm_cdf((1-mu) / sigma)) + sigma * norm_pdf((1-mu) / sigma)
 
-def jump_relu_prime_ev(mu: ArrayType, sigma: ArrayType) -> ArrayType:
+# By default, we include the Dirac delta term in the expected value of the derivative
+# since relu_prime is equal to theta(x-1) + dirac_delta(x-1), but since we're also
+# doing some estimates of it approximately, we need the example without the Dirac delta
+# because the Monte Carlo sampler will not sample exactly x=1.
+def jump_relu_prime_ev(mu: ArrayType, sigma: ArrayType, include_dirac_delta_term: bool = True) -> ArrayType:
     """Expected value of JumpReLU'(x) under N(mu, sigma)"""
-    return norm_cdf((mu-1) / sigma)
+    normal_term = norm_cdf((mu-1) / sigma)
+
+    if include_dirac_delta_term:
+        return normal_term + norm_pdf((mu-1) / sigma) # Include the Dirac delta term
+    else:
+        return normal_term
 
 
 def jump_relu_poly_ev(n: int, mu: ArrayType, sigma: ArrayType) -> ArrayType:

--- a/polyapprox/ols.py
+++ b/polyapprox/ols.py
@@ -21,6 +21,7 @@ from .integrate import (
     master_theorem,
 )
 from .relu import relu_ev, relu_poly_ev, relu_prime_ev
+from .jump_relu import jump_relu_ev, jump_relu_poly_ev, jump_relu_prime_ev
 
 
 @dataclass(frozen=True)
@@ -67,6 +68,7 @@ ACT_TO_EVS = {
     "sigmoid": partial(gauss_hermite, sigmoid),
     "swish": partial(gauss_hermite, swish),
     "tanh": partial(gauss_hermite, np.tanh),
+    "jump_relu": jump_relu_ev,
 }
 # Mapping from activation functions to EVs of their derivatives
 ACT_TO_PRIME_EVS = {
@@ -76,6 +78,7 @@ ACT_TO_PRIME_EVS = {
     "sigmoid": partial(gauss_hermite, sigmoid_prime),
     "swish": partial(gauss_hermite, swish_prime),
     "tanh": partial(gauss_hermite, lambda x: 1 - np.tanh(x) ** 2),
+    "jump_relu": jump_relu_prime_ev,
 }
 ACT_TO_POLY_EVS = {
     "gelu": gelu_poly_ev,
@@ -83,6 +86,7 @@ ACT_TO_POLY_EVS = {
     "relu": relu_poly_ev,
     "sigmoid": sigmoid_poly_ev,
     "swish": swish_poly_ev,
+    "jump_relu": jump_relu_poly_ev,
 }
 
 

--- a/tests/test_jump_relu.py
+++ b/tests/test_jump_relu.py
@@ -9,6 +9,10 @@ from scipy.stats import norm
 
 from polyapprox.jump_relu import jump_relu_ev, jump_relu_poly_ev, jump_relu_prime_ev
 
+# NB: This is mostly a copy of test_relu.py, with the ReLU replaced with JumpReLU
+# The main difference is that we have added 1e-14 to the error tolerance, because
+# the sharpness of JumpReLU makes quad have a hard time estimating the error.
+# Frankly. 1e-14 error is good enough for anyone.
 
 def jump_relu(x):
     """JumpReLU(x) activation function, with theta = 1.0"""
@@ -31,8 +35,8 @@ def test_jump_relu_evs(mu, sigma):
     numerical_ev, err = quad(
         lambda x: jump_relu(x) * norm.pdf(x, loc=mu, scale=sigma), -np.inf, np.inf
     )
-    np.testing.assert_allclose(numerical_ev, analytic_ev, atol=err)
-    torch_test(jump_relu_ev, numerical_ev, mu, sigma, atol=err)
+    np.testing.assert_allclose(numerical_ev, analytic_ev, atol=1e-15 + err)
+    torch_test(jump_relu_ev, numerical_ev, mu, sigma, atol=1e-15 + err)
 
 
 @given(st.floats(-4, 4), st.floats(0.1, 10))
@@ -43,8 +47,8 @@ def test_relu_prime_evs(mu, sigma):
         -np.inf,
         np.inf,
     )
-    np.testing.assert_allclose(numerical_ev, analytic_ev, atol=err)
-    torch_test(jump_relu_prime_ev, numerical_ev, mu, sigma, atol=err)
+    np.testing.assert_allclose(numerical_ev, analytic_ev, atol=1e-15 + err)
+    torch_test(jump_relu_prime_ev, numerical_ev, mu, sigma, atol=1e-15 + err)
 
 
 @given(st.integers(0, 5), st.floats(-4, 4), st.floats(0.1, 10))
@@ -55,7 +59,5 @@ def test_jump_relu_poly_evs(n, mu, sigma):
         -np.inf,
         np.inf,
     )
-    # Don't use relative tolerance because the expected value can be very small.
-    # The sharpness of ReLU also makes quad have a hard time estimating the error.
-    assert abs(numerical_ev - analytic_ev) < 1e-15 + err
-    torch_test(partial(jump_relu_poly_ev, n), numerical_ev, mu, sigma, atol=1e-15 + err)
+    assert abs(numerical_ev - analytic_ev) < 1e-14 + err
+    torch_test(partial(jump_relu_poly_ev, n), numerical_ev, mu, sigma, atol=1e-14 + err)

--- a/tests/test_jump_relu.py
+++ b/tests/test_jump_relu.py
@@ -10,9 +10,10 @@ from scipy.stats import norm
 from polyapprox.jump_relu import jump_relu_ev, jump_relu_poly_ev, jump_relu_prime_ev
 
 # NB: This is mostly a copy of test_relu.py, with the ReLU replaced with JumpReLU
-# The main difference is that we have added 1e-14 to the error tolerance, because
-# the sharpness of JumpReLU makes quad have a hard time estimating the error.
-# Frankly. 1e-14 error is good enough for anyone.
+# The main difference is that we have added 1e-10 to the error tolerance in the
+# jump_relu_poly_ev test, and 1e-15 elsewhere because the sharpness of JumpReLU 
+# makes quad have a hard time estimating the error.
+# Frankly. 1e-10 error is good enough for anyone.
 
 # Disable the dirac delta term in the expected value of the derivative
 jump_relu_prime_ev = partial(jump_relu_prime_ev, include_dirac_delta_term=False)
@@ -62,5 +63,5 @@ def test_jump_relu_poly_evs(n, mu, sigma):
         -np.inf,
         np.inf,
     )
-    assert abs(numerical_ev - analytic_ev) < 1e-9 + err
-    torch_test(partial(jump_relu_poly_ev, n), numerical_ev, mu, sigma, atol=1e-9 + err)
+    assert abs(numerical_ev - analytic_ev) < 1e-10 + err
+    torch_test(partial(jump_relu_poly_ev, n), numerical_ev, mu, sigma, atol=1e-10 + err)

--- a/tests/test_jump_relu.py
+++ b/tests/test_jump_relu.py
@@ -14,6 +14,9 @@ from polyapprox.jump_relu import jump_relu_ev, jump_relu_poly_ev, jump_relu_prim
 # the sharpness of JumpReLU makes quad have a hard time estimating the error.
 # Frankly. 1e-14 error is good enough for anyone.
 
+# Disable the dirac delta term in the expected value of the derivative
+jump_relu_prime_ev = partial(jump_relu_prime_ev, include_dirac_delta_term=False)
+
 def jump_relu(x):
     """JumpReLU(x) activation function, with theta = 1.0"""
     return np.where(x > 1.0, x, 0)

--- a/tests/test_jump_relu.py
+++ b/tests/test_jump_relu.py
@@ -1,0 +1,61 @@
+from functools import partial
+
+import numpy as np
+import torch
+from hypothesis import given
+from hypothesis import strategies as st
+from scipy.integrate import quad
+from scipy.stats import norm
+
+from polyapprox.jump_relu import jump_relu_ev, jump_relu_poly_ev, jump_relu_prime_ev
+
+
+def jump_relu(x):
+    """JumpReLU(x) activation function, with theta = 1.0"""
+    return np.where(x > 1.0, x, 0)
+
+
+def jump_relu_prime(x):
+    """Derivative of JumpReLU(x) with theta = 1.0"""
+    return np.where(x > 1.0, 1.0, 0.0)
+
+
+def torch_test(f, target, *args, atol=1e-12):
+    res = f(*map(lambda x: torch.tensor(x, dtype=torch.double), args))
+    assert abs(res - target) < atol + torch.finfo(torch.double).eps
+
+
+@given(st.floats(-4, 4), st.floats(0.1, 10))
+def test_jump_relu_evs(mu, sigma):
+    analytic_ev = jump_relu_ev(mu, sigma)
+    numerical_ev, err = quad(
+        lambda x: jump_relu(x) * norm.pdf(x, loc=mu, scale=sigma), -np.inf, np.inf
+    )
+    np.testing.assert_allclose(numerical_ev, analytic_ev, atol=err)
+    torch_test(jump_relu_ev, numerical_ev, mu, sigma, atol=err)
+
+
+@given(st.floats(-4, 4), st.floats(0.1, 10))
+def test_relu_prime_evs(mu, sigma):
+    analytic_ev = jump_relu_prime_ev(mu, sigma)
+    numerical_ev, err = quad(
+        lambda x: jump_relu_prime(x) * norm.pdf(x, loc=mu, scale=sigma),
+        -np.inf,
+        np.inf,
+    )
+    np.testing.assert_allclose(numerical_ev, analytic_ev, atol=err)
+    torch_test(jump_relu_prime_ev, numerical_ev, mu, sigma, atol=err)
+
+
+@given(st.integers(0, 5), st.floats(-4, 4), st.floats(0.1, 10))
+def test_jump_relu_poly_evs(n, mu, sigma):
+    analytic_ev = jump_relu_poly_ev(n, np.array(mu), np.array(sigma))
+    numerical_ev, err = quad(
+        lambda x: x**n * jump_relu(x) * norm.pdf(x, loc=mu, scale=sigma),
+        -np.inf,
+        np.inf,
+    )
+    # Don't use relative tolerance because the expected value can be very small.
+    # The sharpness of ReLU also makes quad have a hard time estimating the error.
+    assert abs(numerical_ev - analytic_ev) < 1e-15 + err
+    torch_test(partial(jump_relu_poly_ev, n), numerical_ev, mu, sigma, atol=1e-15 + err)

--- a/tests/test_jump_relu.py
+++ b/tests/test_jump_relu.py
@@ -62,5 +62,5 @@ def test_jump_relu_poly_evs(n, mu, sigma):
         -np.inf,
         np.inf,
     )
-    assert abs(numerical_ev - analytic_ev) < 1e-14 + err
-    torch_test(partial(jump_relu_poly_ev, n), numerical_ev, mu, sigma, atol=1e-14 + err)
+    assert abs(numerical_ev - analytic_ev) < 1e-9 + err
+    torch_test(partial(jump_relu_poly_ev, n), numerical_ev, mu, sigma, atol=1e-9 + err)

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -7,6 +7,11 @@ from statsmodels.regression.linear_model import OLS
 from polyapprox.gelu import gelu
 from polyapprox.ols import ols
 
+ols_monte_carlo_tolerance = {
+    "relu": 0.0,
+    "gelu": 0.0,
+    "jump_relu": 0.05,
+}
 
 def relu(x):
     return np.maximum(0, x)
@@ -105,5 +110,8 @@ def test_ols_monte_carlo(act: str, k: int):
     lo, hi = empirical.conf_int(0.01).T
     analytic_beta = analytic.beta.squeeze()
 
-    assert lo[0] < analytic.alpha < hi[0]
-    assert np.all((lo[1:] < analytic_beta) & (analytic_beta < hi[1:]))
+    # Add a variable tolerance for the Monte Carlo check
+    tol = ols_monte_carlo_tolerance[act]
+
+    assert lo[0] - tol < analytic.alpha < hi[0] + tol
+    assert np.all((lo[1:] - tol < analytic_beta) & (analytic_beta < hi[1:] + tol))


### PR DESCRIPTION
Added an option for JumpReLU activated MLP layers (with theta fixed at 1.0, but this doesn't lose any generality) as used in in sparse autoencoders/transcoders/crosscoders.
Created: polyapprox/jump_relu.py which follows the same format as relu.py but for the JumpReLU activation function
Created: polyapprox/test_jump_relu.py, as above but with slightly less strict error tolerances due to issues described below
Edited: polyapprox/ols.py, just added the imports and options for JumpReLU
Edited: tests/test_ols.py, added tests for JumpReLU, but with a larger error tolerance than existing tests, due to reasons described below. Minor syntax changes to facilitate this, but the functionality of existing ReLU and GELU tests should be unchanged.

There's a couple of snags which both seem to arise because JumpReLU is discontinuous:
1. The derivative of JumpReLU is \Theta(x) + \delta(x) i.e. the Heaviside step function + the Dirac delta function. This means we cannot estimate E[f'(x)] using monte-carlo methods, so we can't really test whether f'(x) is any good (we can run tests on f'(x) without the dirac component, which is what I've done). 
2. test_ols.py/test_ols_monte_carlo fails for JumpReLU as is, with a few components of beta being slightly outside of the 99% CI. Currently I've pulled a Claude here and modified the test to include an additional tolerance (which is set to 0 for relu and gelu, but 0.05 for jump_relu; the existing tests will behave as before) so we can at least be sure that our analytic ols is roughly right compared to the estimated one. I don't know if it's the estimator getting confused or the analytic system is being janky, but I haven't actually changed any of the analytic solver components, and the specific estimators seem to pass their tests.